### PR TITLE
Do not require storage.buckets.get permission

### DIFF
--- a/gsiam.py
+++ b/gsiam.py
@@ -136,7 +136,7 @@ class GCSGrabber(object):
 
   def __init__(self, bucket, path, project):
     self.client = storage.Client()
-    self.bucket = self.client.get_bucket(bucket)
+    self.bucket = self.client.bucket(bucket)
     self.base_path = path
     self.verbose_logger = logging.getLogger("yum.verbose.plugin.GCSGrabber")
 


### PR DESCRIPTION
If the service account doesn't have the `storage.buckets.get` permission on the GCS bucket containing the yum repository it errors with:

`google.api_core.exceptions.Forbidden: 403 GET https://storage.googleapis.com/storage/v1/b/bucket-name?projection=noAcl: service-account-name@project-name.iam.gserviceaccount.com does not have storage.buckets.get access to bucket-name.`

This permission is only used for accessing bucket metadata - it is not required to list or read files.

I've implemented the solution explained in this issue: https://github.com/googleapis/google-cloud-python/issues/9065

which causes the google API to not attempt to retrieve metadata.

This seems to be working fine in my environment.