### PR TITLE
Use init hook instead of prereposetup

### DIFF
--- a/gsiam.py
+++ b/gsiam.py
@@ -55,7 +55,7 @@ def replace_repo(repos, repo):
     repos.add(GCSRepository(repo.id, repo))
 
 
-def prereposetup_hook(conduit):
+def init_hook(conduit):
   """Plugin initialization hook. Setup the GCS repositories."""
   repos = conduit.getRepos()
   for repo in repos.listEnabled():


### PR DESCRIPTION
I ran into this issue: https://github.com/tellapart/yum-gs-iam/issues/3

When debugging, I could see that Yum was hitting the error inside the _baseurlSetup method: http://yum.baseurl.org/download/docs/yum-api/3.2.27/yum.yumRepo-pysrc.html#YumRepository._baseurlSetup

I added `conduit.info(2, 'prereposetup_hook')` at the beginning of the `prereposetup_hook` method and as far as I could see it was never being called. Using the `init_hook` caused the code to run and everything started working. No idea if this is specific to the version of Yum I'm using or what - and I have no idea if there will be unintended side effects of using the init hook instead, but this seems to be working for me..

Yum version: 3.4.3
CentOS 7